### PR TITLE
Use `1 <name>` instead of `1::<name>`

### DIFF
--- a/assets/self-syntax.txt
+++ b/assets/self-syntax.txt
@@ -3,25 +3,25 @@ inv: "inverted"
 prop: "property"
 any: "any_characters"
 seps: "[]{}():.!?"
-1::"string" [..seps!"name" ":" w? t?"text"]
-2::"node" [$"id" "::" t!"name" w! @"rule""rule"]
-3::"set" {t!"value" ..seps!"ref"}
-4::"opt" {"?"(opt) "!"(!opt)}
-5::"number" ["$" ?("_"("underscore")) ?(@"set"prop)]
-6::"text" ["t" {"?"("allow_empty") "!"(!"allow_empty")} ?(@"set"prop)]
-7::"reference" ["@" t!"name" ?(@"set"prop)]
-8::"sequence" ["[" w? s!.(w!) {@"rule""rule"} "]"]
-9::"select" ["{" w? s!.(w!) {@"rule""rule"} "}"]
-10::"separated_by" ["s" @"opt" ?("."("allow_trail"))
+1 "string" [..seps!"name" ":" w? t?"text"]
+2 "node" [$"id" w! t!"name" w! @"rule""rule"]
+3 "set" {t!"value" ..seps!"ref"}
+4 "opt" {"?"(opt) "!"(!opt)}
+5 "number" ["$" ?("_"("underscore")) ?(@"set"prop)]
+6 "text" ["t" {"?"("allow_empty") "!"(!"allow_empty")} ?(@"set"prop)]
+7 "reference" ["@" t!"name" ?(@"set"prop)]
+8 "sequence" ["[" w? s!.(w!) {@"rule""rule"} "]"]
+9 "select" ["{" w? s!.(w!) {@"rule""rule"} "}"]
+10 "separated_by" ["s" @"opt" ?("."("allow_trail"))
   "(" w? @"rule""by" w? ")" w? "{" w? @"rule""rule" w? "}"]
-11::"token" [@"set""text" ?(["(" w? ?("!"(inv)) @"set"prop w? ")"])]
-12::"optional" ["?(" w? @"rule""rule" w? ")"]
-13::"whitespace" ["w" @"opt"]
-14::"until_any_or_whitespace" [".." @"set"any @"opt" ?(@"set"prop)]
-15::"until_any" ["..." @"set"any @"opt" ?(@"set"prop)]
-16::"repeat" ["r" @"opt" "(" @"rule""rule" ")"]
-17::"lines" ["l(" w? @"rule""rule" w? ")"]
-18::"rule" {
+11 "token" [@"set""text" ?(["(" w? ?("!"(inv)) @"set"prop w? ")"])]
+12 "optional" ["?(" w? @"rule""rule" w? ")"]
+13 "whitespace" ["w" @"opt"]
+14 "until_any_or_whitespace" [".." @"set"any @"opt" ?(@"set"prop)]
+15 "until_any" ["..." @"set"any @"opt" ?(@"set"prop)]
+16 "repeat" ["r" @"opt" "(" @"rule""rule" ")"]
+17 "lines" ["l(" w? @"rule""rule" w? ")"]
+18 "rule" {
   @"whitespace""whitespace"
   @"until_any_or_whitespace""until_any_or_whitespace"
   @"until_any""until_any"
@@ -36,4 +36,4 @@ seps: "[]{}():.!?"
   @"token""token"
   @"optional""optional"
 }
-19::"document" [l(@"string""string") l(@"node""node") w?]
+19 "document" [l(@"string""string") l(@"node""node") w?]

--- a/assets/syntax.txt
+++ b/assets/syntax.txt
@@ -1,17 +1,17 @@
 seps: "()[]{},;:/*+-"
-1::"brackets" s?(w!) { ?(["[" {":" ..seps!} "]"]) }
-2::"path" [?("::"("root")) s!.("::") { ..seps!"name" }]
-3::"arg" [1"brackets" 2"path" 1"brackets" ?(5"repeated_arguments")]
-4::"arguments" ["(" w? s?.(["," w!]) { {$_"number" t?"text"
+1 "brackets" s?(w!) { ?(["[" {":" ..seps!} "]"]) }
+2 "path" [?("::"("root")) s!.("::") { ..seps!"name" }]
+3 "arg" [1"brackets" 2"path" 1"brackets" ?(5"repeated_arguments")]
+4 "arguments" ["(" w? s?.(["," w!]) { {$_"number" t?"text"
   4"arguments" 11"member_lambda" 7"lambda" 3"arg"} } w? ")"]
-5::"repeated_arguments" r!(4"arguments")
-6::"comment" [w? "//" ..."\n"?]
-7::"lambda" [w? ?(["fn" w?]) ..seps?"name" w?
+5 "repeated_arguments" r!(4"arguments")
+6 "comment" [w? "//" ..."\n"?]
+7 "lambda" [w? ?(["fn" w?]) ..seps?"name" w?
   1"brackets" 5"repeated_arguments" w! "->" w! 3"arg" w?]
-8::"fn" [?(["pub" w?]) 7"lambda" ";" w? ?(6"comment")]
-9::"use" [w? ?(["pub" w?]) "use" w! 2"path" ?("*") ";"]
-10::"module" [w? ?(["pub" w?]) "mod" w! ..seps!"name" ";"]
-11::"member_lambda" [3"arg" w? ":" w! 3"arg"]
-12::"member" [11"member_lambda" ";"]
-13::"line_rule" {6"comment" 9"use" 10"module" 12"member" 8"fn"}
-14::"document" l(13"line_rule")
+8 "fn" [?(["pub" w?]) 7"lambda" ";" w? ?(6"comment")]
+9 "use" [w? ?(["pub" w?]) "use" w! 2"path" ?("*") ";"]
+10 "module" [w? ?(["pub" w?]) "mod" w! ..seps!"name" ";"]
+11 "member_lambda" [3"arg" w? ":" w! 3"arg"]
+12 "member" [11"member_lambda" ";"]
+13 "line_rule" {6"comment" 9"use" 10"module" 12"member" 8"fn"}
+14 "document" l(13"line_rule")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ pub fn meta_rules() -> Vec<(Rc<String>, Rule)> {
         ]
     });
 
-    // 2."node" [$("id") "." t!("name") w! @"rule"("rule")]
+    // 2 "node" [$"id" w! t!"name" w! @"rule""rule"]
     let node_rule = Rule::Sequence(Sequence {
         debug_id: 2000,
         args: vec![
@@ -640,11 +640,9 @@ pub fn meta_rules() -> Vec<(Rc<String>, Rule)> {
                 allow_underscore: false,
                 property: Some(Rc::new("id".into())),
             }),
-            Rule::Token(Token {
+            Rule::Whitespace(Whitespace {
                 debug_id: 2002,
-                text: Rc::new("::".into()),
-                inverted: false,
-                property: None,
+                optional: false,
             }),
             Rule::Text(Text {
                 debug_id: 2003,


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/math_notation/issues/34